### PR TITLE
cp39だけビルドされない問題を解消してパッチバージョンをbumpした

### DIFF
--- a/bindings/python3/Cargo.toml
+++ b/bindings/python3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chanoma-py"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["booink <booink.work@gmail.com>"]
 edition = "2021"
 

--- a/bindings/python3/Dockerfile
+++ b/bindings/python3/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/pypa/manylinux_2_24_x86_64
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+ENV PATH="/root/.cargo/bin:$PATH"
+
+WORKDIR /io/bindings/python3

--- a/bindings/python3/README.md
+++ b/bindings/python3/README.md
@@ -21,7 +21,7 @@ if __name__ == '__main__':
 ## インストール
 
 ```sh
-pip install git+https://github.com/booink/chanoma/tree/main/bindings/python3
+pip install chanoma
 ```
 
 ## 設定ファイル
@@ -94,9 +94,21 @@ modifiers:
 ## Development
 
 ```sh
-docker-compose build
+docker-compose build chanoma
 docker-compose run --rm chanoma bash
 cd /app/bindings/python3
 python3 ./setup.py develop
 ./run-test.sh
+```
+
+## Build
+
+```sh
+docker-compose run --rm build-wheels-for-python ./build-wheels.sh
+```
+
+## Publish
+
+```sh
+docker-compose run --rm chanoma ./bindings/python3/publish_to_pypi.sh
 ```

--- a/bindings/python3/build-wheels.sh
+++ b/bindings/python3/build-wheels.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
-export PATH="$HOME/.cargo/bin:$PATH"
+rm -f -r chanoma.egg-info/* dist/*
 
-cd /io
-
-for PYBIN in /opt/python/cp{36,37,38,39}*/bin; do
+for PYBIN in /opt/python/cp{37,38,39,310}*/bin; do
   "${PYBIN}/pip" install -U setuptools wheel setuptools-rust
+  "${PYBIN}/python" setup.py sdist
   "${PYBIN}/python" setup.py bdist_wheel
 done
 
-for whl in dist/*.whl; do
-  auditwheel repair "$whl" -w dist/
+for whl in dist/*-linux_x86_64.whl; do
+  auditwheel repair "$whl" -w dist/ --plat manylinux_2_28_x86_64
+  rm $whl
 done

--- a/bindings/python3/publish_to_pypi.sh
+++ b/bindings/python3/publish_to_pypi.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# https://qiita.com/shinichi-takii/items/e90dcf7550ef13b047b5
+
+cd bindings/python3
+
+pip3 install -r requirements.txt
+
+# 本番アップロード
+twine upload --repository pypi dist/*

--- a/bindings/python3/requirements.txt
+++ b/bindings/python3/requirements.txt
@@ -1,2 +1,4 @@
 setuptools-rust>=1.2.0
 pytest
+wheel
+twine

--- a/bindings/python3/setup.py
+++ b/bindings/python3/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(
     name="chanoma",
-    version="0.1.0",
+    version="0.1.1",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Development Status :: 3 - Alpha",
@@ -18,4 +22,11 @@ setup(
         "chanoma.chanoma", "Cargo.toml", debug=False, binding=Binding.PyO3)],
     include_package_data=True,
     zip_safe=False,
+    url="https://github.com/booink/chanoma/tree/main/bindings/python3",
+    description='chanoma is Characters Normalization library.文字列正規化処理用のライブラリです。',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author='Booink',
+    author_email='booink.work@gmail.com',
+    keywords=['japanese', 'normalize'],
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,9 @@ services:
       context: .
     volumes:
       - .:/app
+  build-wheels-for-python:
+    build:
+      context: bindings/python3
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/io

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-//use chanoma::{chanoma::table::Origin, chanoma::PreparedTable, Chanoma};
 use chanoma::Chanoma;
 use clap::Parser;
 use std::io;


### PR DESCRIPTION
* cp39がバンドルされない問題を解消した
  * auditwheelのオプションに `--plat manylinux_2_28_x86_64` を付けたらうまくいった
* READMEがpypiで表示されるようにlong_descriptionを設定した